### PR TITLE
To avoid this

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone https://github.com/Istalantar/scj2024-eclectic-eclipses
 3. Navigate to the root of the repository and run the following command. Poetry will create a virtual environment and install all the necessary dependencies in it.
 
 ```bash
-poetry install
+poetry install --no-root
 ```
 
 4. Optionally, if you want to contribute to this project, install the pre-commit hook for your local repository by running the following command:


### PR DESCRIPTION
`Warning: The current project could not be installed: No file/folder found for package scj2024-eclectic-eclipses
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!`